### PR TITLE
Add UnifAPI Skills resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Skill-centric evaluation should measure more than final task success. Important 
 | **SkillHub** | https://www.skillhub.club/ | Community skill resources |
 | **SkillsMP** | https://skillsmp.com/ | Marketplace-style skill ecosystem |
 | **Skills.sh** | https://skills.sh/ | Agent skill publishing and reuse |
+| **UnifAPI Skills** | https://github.com/unifapi-agent/skills | Public-data MCP and KOL pricing skill package for Codex and Claude-compatible agent workflows |
 
 <a id="application-scenarios"></a>
 


### PR DESCRIPTION
## Summary
- Add UnifAPI Skills to the ecosystem platforms and resources table.
- Link to the public UnifAPI skills repository for public-data MCP and KOL pricing workflows.

## Validation
- `git diff --check`
- Verified the UnifAPI skills repository URL returns 200.