### PR TITLE
Add Tree Ring Memory to ecosystem resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Skill-centric evaluation should measure more than final task success. Important 
 | **Skills.sh** | https://skills.sh/ | Agent skill publishing and reuse |
 | **Hermes Tweet** | https://github.com/Xquik-dev/hermes-tweet | Hermes Agent X/Twitter plugin with bundled skill metadata and safe-default social workflow execution |
 | **ax** | https://github.com/Necmttn/ax | Local telemetry graph for coding-agent sessions, skills, tools, and workflow recall |
+| **Tree Ring Memory** | https://github.com/TerminallyLazy/Tree-Ring-Memory | Local-first memory framework for coding agents with lifecycle-aware recall, evidence-backed promotion, forgetting, and a portable Agent Skill package |
 | **UnifAPI Skills** | https://github.com/unifapi-agent/skills | Public-data MCP and KOL pricing skill package for Codex and Claude-compatible agent workflows |
 | **Before You Build Skill** | https://github.com/bin1874/before-you-build-skill | Pre-build product and feature risk review skill for AI coding agents |
 


### PR DESCRIPTION
Adds Tree Ring Memory to the ecosystem platforms/resources table as a local-first memory framework for coding agents with a portable Agent Skill package.

Fit: the contribution section accepts projects/platforms, and the existing table includes adjacent skill ecosystem tools for coding-agent workflow recall and reusable skills.

Validation:
- Checked for existing Tree Ring Memory PRs/listing; none found.
- Verified the project link returns HTTP 200.
- Checked the ecosystem resources table still has three columns.
- Ran `git -c core.whitespace=cr-at-eol diff --check` because the upstream README uses CRLF line endings.