### PR TITLE
Add Maoxuan Product Agent resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Skill-centric evaluation should measure more than final task success. Important 
 | **Tree Ring Memory** | https://github.com/TerminallyLazy/Tree-Ring-Memory | Local-first memory framework for coding agents with lifecycle-aware recall, evidence-backed promotion, forgetting, and a portable Agent Skill package |
 | **UnifAPI Skills** | https://github.com/unifapi-agent/skills | Public-data MCP and KOL pricing skill package for Codex and Claude-compatible agent workflows |
 | **Before You Build Skill** | https://github.com/bin1874/before-you-build-skill | Pre-build product and feature risk review skill for AI coding agents |
+| **Maoxuan Product Agent** | https://github.com/atdy/maoxuan-product-agent | Chinese-first product decision skill distilled from *On Practice* and *On Contradiction*, with 36 scenario playbooks for Codex, Claude Code, and Cursor |
 
 <a id="application-scenarios"></a>
 


### PR DESCRIPTION
## Summary

Add Maoxuan Product Agent to the Ecosystem Platforms and Resources table.

It is a Chinese-first product decision Agent Skill distilled from the complete reasoning structures of *On Practice* and *On Contradiction*. It translates that reasoning into modern product work rather than exposing quotations or historical framing.

## Why it fits

- Packages human-derived procedural knowledge as a portable SKILL.md
- Supports Codex, Claude Code, Cursor, and compatible agents
- Includes 36 product scenario playbooks and a quality gate
- Has been evaluated against 30+ realistic product cases
- MIT licensed and fully documented

## Scope

One README row only. The repository link returns HTTP 200 and the diff passes the Git whitespace check.
