### PR TITLE
Add Markstream Skills to ecosystem resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Skill-centric evaluation should measure more than final task success. Important 
 | **Skills.sh** | https://skills.sh/ | Agent skill publishing and reuse |
 | **BrowserAct Skills** | https://github.com/browser-act/skills | Browser automation skills for AI agents with local Chrome reuse, isolated sessions, and human handoff |
 | **Hermes Tweet** | https://github.com/Xquik-dev/hermes-tweet | Hermes Agent X/Twitter plugin with bundled skill metadata and safe-default social workflow execution |
+| **Markstream Skills** | https://github.com/Simon-He95/markstream-vue/tree/main/.agents/skills | Framework-specific skills for streaming Markdown across Vue, React, Svelte, Angular, Nuxt, Next.js, and Vue 2 |
 | **ax** | https://github.com/Necmttn/ax | Local telemetry graph for coding-agent sessions, skills, tools, and workflow recall |
 | **Tree Ring Memory** | https://github.com/TerminallyLazy/Tree-Ring-Memory | Local-first memory framework for coding agents with lifecycle-aware recall, evidence-backed promotion, forgetting, and a portable Agent Skill package |
 | **UnifAPI Skills** | https://github.com/unifapi-agent/skills | Public-data MCP and KOL pricing skill package for Codex and Claude-compatible agent workflows |


### PR DESCRIPTION
## Summary

Add Markstream Skills to the Ecosystem Platforms and Resources table.

Markstream maintains 11 reusable Agent Skills for installing, configuring, customizing, and migrating streaming Markdown renderers across Vue, React, Svelte, Angular, Nuxt, Next.js, and Vue 2.

## Checks

- Searched the repository and confirmed there is no existing Markstream entry.
- Linked directly to the public skills collection.
- Confirmed the link returns HTTP 200.
- Kept the addition to one concise resource-table row.
- `git diff --check` passes.

Thank you for curating this research and ecosystem hub.
