### PR TITLE
Add UIZZE to ecosystem resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ Skill-centric evaluation should measure more than final task success. Important 
 | **SkillsMP** | https://skillsmp.com/ | Marketplace-style skill ecosystem |
 | **Skills.sh** | https://skills.sh/ | Agent skill publishing and reuse |
 | **BrowserAct Skills** | https://github.com/browser-act/skills | Browser automation skills for AI agents with local Chrome reuse, isolated sessions, and human handoff |
+| **UIZZE** | https://uizze.com | Free anti-UI-slop skill and 800,000+ real web and iOS product screens for Codex, Claude Code, Cursor, and other coding agents |
 | **Hermes Tweet** | https://github.com/Xquik-dev/hermes-tweet | Hermes Agent X/Twitter plugin with bundled skill metadata and safe-default social workflow execution |
 | **ax** | https://github.com/Necmttn/ax | Local telemetry graph for coding-agent sessions, skills, tools, and workflow recall |
 | **Tree Ring Memory** | https://github.com/TerminallyLazy/Tree-Ring-Memory | Local-first memory framework for coding agents with lifecycle-aware recall, evidence-backed promotion, forgetting, and a portable Agent Skill package |


### PR DESCRIPTION
## Summary

Add UIZZE to Ecosystem Platforms and Resources.

UIZZE publishes a free Agent Skills-compatible anti-UI-slop workflow and a searchable catalogue of 800,000+ real web and iOS product screens for coding agents.

Public skill: https://uizze.com/.well-known/agent-skills/anti-ui-slop/SKILL.md
