### PR TITLE
Add Duvo Skills to ecosystem resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@ Skill-centric evaluation should measure more than final task success. Important 
 | **UnifAPI Skills** | https://github.com/unifapi-agent/skills | Public-data MCP and KOL pricing skill package for Codex and Claude-compatible agent workflows |
 | **RunAPI CLI Skill** | https://github.com/runapi-ai/cli-skill | Agent workflow skill for running RunAPI image, video, music/audio, and LLM model jobs from Codex and Claude-compatible agents |
 | **Orkas VideoStudio** | https://github.com/Orkas-AI/Orkas-VideoStudio | Source-installable video skills and MCP tools for Codex and Claude Code with editable timelines |
+| **Duvo Skills** | https://github.com/duvoai/skills | Public agent skills for grocery and retail operations execution; SOP writer, run debugger, and CLI driver across existing systems |
 | **Before You Build Skill** | https://github.com/bin1874/before-you-build-skill | Pre-build product and feature risk review skill for AI coding agents |
 | **skillZs** | https://skillzs.dev/ | Agent Skills discovery, guides, and security resources |
 


### PR DESCRIPTION
## Summary

Adds Duvo Skills to **Ecosystem Platforms and Resources**.

1. **Title:** Duvo Skills
2. **Venue and year:** GitHub, May 2026 (public MIT repo)
3. **Link:** https://github.com/duvoai/skills
4. **Suggested category:** Ecosystem Platforms and Resources

Public agent skills pack (7 `SKILL.md` files) for grocery and retail operations execution: SOP writer, run debugger, and CLI driver across existing systems. Install with `npx skills add duvoai/skills`. Same table format as recent ecosystem adds (Orkas VideoStudio, RunAPI CLI Skill, BrowserAct Skills).