### PR TITLE
docs: refresh UIZZE resource entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Skill-centric evaluation should measure more than final task success. Important 
 | **SkillsMP** | https://skillsmp.com/ | Marketplace-style skill ecosystem |
 | **Skills.sh** | https://skills.sh/ | Agent skill publishing and reuse |
 | **BrowserAct Skills** | https://github.com/browser-act/skills | Browser automation skills for AI agents with local Chrome reuse, isolated sessions, and human handoff |
-| **UIZZE** | https://uizze.com | Free MIT anti-ui-slop Skill with a no-account preview at https://uizze.com/mcp/preview; full UIZZE adds live reference search, validation, and audits across 800,000+ real web and iOS screens for Codex, Claude Code, Cursor, and other coding agents |
+| **UIZZE** | https://uizze.com | Free MIT anti-ui-slop Skill and conservative GitHub Action for coding agents; optional authenticated UIZZE MCP provides live reference search and hosted design materials grounded in 800,000+ real web and iOS screens |
 | **Hermes Tweet** | https://github.com/Xquik-dev/hermes-tweet | Hermes Agent X/Twitter plugin with bundled skill metadata and safe-default social workflow execution |
 | **Markstream Skills** | https://github.com/Simon-He95/markstream-vue/tree/main/.agents/skills | Framework-specific skills for streaming Markdown across Vue, React, Svelte, Angular, Nuxt, Next.js, and Vue 2 |
 | **ax** | https://github.com/Necmttn/ax | Local telemetry graph for coding-agent sessions, skills, tools, and workflow recall |


### PR DESCRIPTION
This corrects the existing UIZZE resource entry from #29.\n\nThe entry referenced a retired anonymous MCP preview route and tool. It now describes the current free MIT anti-ui-slop Skill, the conservative GitHub Action, and the optional authenticated UIZZE MCP for live reference search and hosted design materials grounded in 800,000+ real web and iOS screens.\n\nChecks:\n- git diff --check\n- Confirmed the canonical site and Skill URL return 200\n- Confirmed no retired preview route or tool remains in the entry\n\nDisclosure: UIZZE is my project. This is a maintenance correction to an existing listing.