### PR TITLE
Add Agent Coordinator to ecosystem resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ Skill-centric evaluation should measure more than final task success. Important 
 | **Before You Build Skill** | https://github.com/bin1874/before-you-build-skill | Pre-build product and feature risk review skill for AI coding agents |
 | **shidi-skill** | https://github.com/IcyCreamDAS/shidi-skill | Bilingual scientific research workflow skill: multi-angle literature review with per-angle files, anchored experiment design with a caveat list, figures, paper reading; returns files plus a cross-verification brief. Zero deps, MIT |
 | **skillZs** | https://skillzs.dev/ | Agent Skills discovery, guides, and security resources |
+| **Agent Coordinator** | https://github.com/alanhoff/agent-coordinator | Per-user Codex skill that coordinates dependency-aware work inline or through optional specialists, records local state, reconciles uncertain work before retry, and reruns authored checks at closeout |
 
 <a id="application-scenarios"></a>
 


### PR DESCRIPTION
## Summary

Adds Agent Coordinator to Ecosystem Platforms and Resources.

1. Title: Agent Coordinator
2. Venue and year: GitHub project, 2026 (MIT)
3. Link: https://github.com/alanhoff/agent-coordinator
4. Suggested category: Ecosystem Platforms and Resources

Agent Coordinator is a per-user Codex skill with a bundled local state owner. One parent controller owns the work graph, integration, recovery, and completion. Specialists are optional; without them, the same node lifecycle runs inline. The row links the canonical repository and sticks to those implemented mechanics.

## Validation

- The public source is current at `fb3d64688a9e1b7c02a114a14faac1219ec10f51`, with a passing main-branch CI run.
- The repository provides a directly usable `skill/SKILL.md`, an MIT license, and documentation for installation, requirements, usage, permissions, local state, and limitations.
- I found no existing listing or matching issue or pull request.
- `git diff --check` passes.
- This pull request changes only `README.md` with one resource-table row.

Disclosure: I maintain Agent Coordinator. I prepared this submission with Codex and reviewed the description against the public source.
