### PR TITLE
Add BulkPublish social media skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ Skill-centric evaluation should measure more than final task success. Important 
 | **SkillHub** | https://www.skillhub.club/ | Community skill resources |
 | **SkillsMP** | https://skillsmp.com/ | Marketplace-style skill ecosystem |
 | **Skills.sh** | https://skills.sh/ | Agent skill publishing and reuse |
+| **BulkPublish Social Media Content Skills** | https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills | Reusable planning, adaptation, review, scheduling, and publishing skills for AI agents, with BulkPublish API/MCP handoff |
 | **BrowserAct Skills** | https://github.com/browser-act/skills | Browser automation skills for AI agents with local Chrome reuse, isolated sessions, and human handoff |
 | **UIZZE** | https://uizze.com | Free MIT anti-ui-slop Skill with a no-account preview at https://uizze.com/mcp/preview; full UIZZE adds live reference search, validation, and audits across 800,000+ real web and iOS screens for Codex, Claude Code, Cursor, and other coding agents |
 | **Hermes Tweet** | https://github.com/Xquik-dev/hermes-tweet | Hermes Agent X/Twitter plugin with bundled skill metadata and safe-default social workflow execution |


### PR DESCRIPTION
Adds BulkPublish Social Media Content Skills to the ecosystem resources. The entry links directly to the reusable skills folder and describes its planning, adaptation, review, scheduling, and publishing handoff through BulkPublish API/MCP. Link verified on 2026-09-02.